### PR TITLE
Fix for calling prematurely

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+/*jshint node:true*/
 'use strict';
 
 var flags = require('next-feature-flags-client');

--- a/main.js
+++ b/main.js
@@ -4,19 +4,22 @@
 var flags = require('next-feature-flags-client');
 var Raven = require('./src/raven');
 
-flags.init().then(function() {
+function init() {
+	flags.init().then(function() {
 
-	if (flags.get('clientErrorReporting').isSwitchedOn) {
-		Raven.config('https://edb56e86be2446eda092e69732d8654b@app.getsentry.com/32594').install();
+		if (flags.get('clientErrorReporting').isSwitchedOn) {
+			Raven.config('https://edb56e86be2446eda092e69732d8654b@app.getsentry.com/32594').install();
 
-		// normalise client and server side method names
-		Raven.captureMessage = Raven.captureException;
-	}
+			// normalise client and server side method names
+			Raven.captureMessage = Raven.captureException;
+		}
 
-	if (flags.get('analytics').isSwitchedOn) {
-		require('./src/tracking');
-	}
+		if (flags.get('analytics').isSwitchedOn) {
+			require('./src/tracking');
+		}
 
-});
+	});
+}
 
 module.exports.raven = Raven;
+module.exports.init = init;


### PR DESCRIPTION
It was calling flags.init() before the polyfills had finished loading, which was causing all the IEs to fall over (due to missing native Promises).